### PR TITLE
First (and likely only) round of line edits.

### DIFF
--- a/freebsd_ports_workflow_git.org
+++ b/freebsd_ports_workflow_git.org
@@ -4,11 +4,11 @@
 
 The FreeBSD ports tree was created in 1994 and tracked using CVS until July 15, 2012 when Subversion took over.  A second repository conversion occurred on April 6, 2021, when the /source of truth/ was migrated from Subversion to Git.  As both CVS and Subversion are centralized version control systems, the required workflow changes associated with the first conversion were not as complex as with the conversion to Git, a distributed version control system.  The goal of this article is to guide those new to either Git, FreeBSD ports, or both through /a/ Git workflow that can be used to contribute to FreeBSD ports.  Topics covered include: a brief overview of concepts in Git, staying up-to-date with remote repositories, working with branches, committing, modifying history, working with Phabricator reviews, testing changes with poudriere, and keeping track of upstream releases.  This is not a comprehensive guide to using Git.  For a thorough introduction to Git, refer to the [[https://git-scm.com/book/][Pro Git book]].  What will also not be covered is how to work with the make specifications that ports and the ports infrastructure are written in.  This is covered in detail in the [[https://docs.freebsd.org/en/books/porters-handbook/book/][FreeBSD Porter's Handbook]].
 
-From an implementation perspective, the defining property that makes Git different from centralized version control systems like Subversion is its support for distributed workflows.  Git does not require a central server that contains /blessed/ copies of the versioned files because 1. copies of the repository are full clones that include meta-data and full history and 2. Git commits are snapshots of the repository rather than delta-based changes to files.  Snapshots are described using hash algorithms that take as input the state of the repository and produce a deterministic hash value in the form of a hexadecimal string.  If two copies of the repository are in the same state, the hash values describing the copies will be the same, whereas two repositories that differ by a single bit flip will produce different hash values.  This ensures the integrity of the repository data.
+From a design and use perspective, the defining property that makes Git different from centralized version control systems like Subversion is its support for distributed workflows.  Git does not require a central server that contains /blessed/ copies of the versioned files because 1. copies of the repository are full clones that include meta-data and full history and 2. Git commits are snapshots of the repository rather than delta-based changes to files.  Snapshots are described using hash algorithms that take as input the state of the repository and produce a deterministic hash value in the form of a hexadecimal string.  If two copies of the repository are in the same state, the hash values describing the copies will be the same, whereas two repositories that differ by a single bit flip will produce different hash values.  This ensures the integrity of the repository data.
 
-The history of a Git repository can be considered as a directed acyclic graph with nodes of the graph repository snapshots.  Creating a new branch means starting a new line of development.  What defines the branch is the commit at its tip and all of its ancestral commits.  Under the hood, creating a new branch simply involves creating a new pointer to a snapshot.  Adding new commits to the branch causes the branch pointer to advance to the tip of the branch.  A typical workflow is to create a new branch (off of the main branch) to develop some new feature or to fix a bug.  When the work in the feature branch is ready, the commits of the feature branch can be merged with the main branch.
+The history of a Git repository is a directed acyclic graph with nodes of the graph being repository snapshots and edges being commits.  Creating a new branch means starting a new line of development; for ports, it will usually propose a new port or upgrade an existing one you maintain.  What defines the branch is the commit at its tip and all of its ancestral commits.  Under the hood, creating a new branch simply creates a new pointer to a snapshot.  Adding new commits to the branch causes the branch pointer to advance to the tip of the branch.  A typical workflow is to create a new branch (off of the main branch) to develop some new feature or to fix a bug.  When the work in the feature branch is ready, the commits of the feature branch can be merged with the main branch.
 
-From a user perspective, support for lightweight local branches and the simplicity of switching between and merging the work of different branches is Git's defining feature.  Because most of this work occurs locally, there is no single workflow that all contributors must subscribe to.  Work the way that best suits you.  However, the official FreeBSD ports repository does enforce certain conventions.  For example, we value a simple linear history, so viewing the history of the FreeBSD ports main branch under Git looks similar to how the history looked under Subversion.  This requires certain constraints when developers push changes to the official repository.  Other projects use a different workflow that results in parallel paths along in the main branch of the repository.  In short, Git is flexible and there is no single workflow that suits all people or projects.  Indeed, at the time of writing there is a FreeBSD working group exploring how we can optimize our Git workflow, so there may be future refinements to how we work with Git.
+From a user perspective, .Git's support of lightweight local branches, easy switching between branches, and merging different branches are its strong points.  Because most of this work occurs locally, there is no single workflow that all contributors must subscribe to.  Work the way that best suits you.  However, the official FreeBSD ports repository does enforce certain conventions.  For example, the ports committers require a simple linear history, so the history of the FreeBSD ports main branch under Git looks similar to how it looked under Subversion.  This requires certain constraints when port committers push changes to the official repository.  Other projects use a different overall process that relies on parallel paths along with the main branch of the repository.  In short, Git is flexible and there is no single workflow that suits all people or projects.  Indeed, a FreeBSD working group was started in October 2021 to explore how we can optimize our Git workflow, so there may be future refinements to how we work with Git.
 
 ** Cloning the Ports Tree
 
@@ -72,13 +72,13 @@ To integrate the new commits from ~freebsd/main~ into our local main branch, run
   git merge freebsd/main --ff-only
 #+end_src
 
-The ~--ff-only~ (fast-forward only) option means only integrate the work from ~freebsd/main~ into ~main~ if it can be done by moving the ~main~ branch pointer to point to the same commit as ~freebsd/main~.  This can only happen when the output of
+The ~--ff-only~ (fast-forward only) option means only integrate the work from ~freebsd/main~ into ~main~ if it can be done by moving the ~main~ branch pointer to point to the same commit as ~freebsd/main~.  If you changed your local main branch directly, these changes are not part of ~freebsd/main~ and ~--ff-only~ will cause the ~merge~ to fail.  To check whether this is the case, run
 
 #+begin_src sh
   git log --oneline main..freebsd/main
 #+end_src
 
-descends from the local main branch.  If changes have been made to the local main branch that are not part of ~freebsd/main~, ~--ff-only~ will cause the ~merge~ to fail.  In the workflow described here, we will never make direct changes to the local main branch, so this should never be a problem, but to be safe, we can configure the ~merge~ command to always use ~--ff-only~ with
+and check for any local changes.  In the workflow described here, we will never make direct changes to the local main branch, so this should never be a problem, but to be safe, we can configure the ~merge~ command to always use ~--ff-only~ with
 
 #+begin_src sh
   git config merge.ff only
@@ -92,7 +92,7 @@ As a convenience, there is a ~pull~ command that will do both the ~fetch~ and ~m
 
 ** Creating a Local Branch
 
-Now that we are able to keep our repository copy up-to-date with git.freebsd.org/ports.git, let's start to think about /creating/ changes.  This is where Git really shines with the use of local branches, which provide a clean and efficient way to keep work-in-progress organized.  Start by creating a new feature branch to work on the new nyxt port.
+Now that we can keep our repository copy up-to-date with git.freebsd.org/ports.git, let's think about /creating/ changes.  This is where Git really shines with the use of local branches, which provide a clean and efficient way to keep work-in-progress organized.  Start by creating a new feature branch to [[https://docs.freebsd.org/en/books/porters-handbook/new-port/][work on the new nyxt port]].
 
 #+begin_src sh
    git branch nyxt
@@ -110,7 +110,7 @@ A shorthand for both creating and switching to a branch is
   git checkout -b nyxt
 #+end_src
 
-If you ever want to check which branch you have checked out, you can run
+To check which branch you have checked out, you can run
 
 #+begin_src sh
   git branch --show-current
@@ -137,7 +137,7 @@ Now ~git status~ will list all the modified or added files as staged and ready t
   git config --add core.hooksPath .hooks
 #+end_src
 
-At the time of writing there is only one hook in that location, ~prepare-commit-msg~, which provides a helpful template for formatting commit messages.  We also want to configure the editor that will be launched to create commit messages.  Git chooses the editor to launch in this order: the value of the ~GIT_EDITOR~ environment variable, its ~core.editor~ configuration variable, the ~VISUAL~ environment variable, and the ~EDITOR~ environment variable.  For example, we can tell Git to use terminal Emacs to edit commit messages with
+That directory contains the prepare-commit-msg hook, which provides a helpful template for formatting commit messages.  We also want to configure the editor that will be launched to create commit messages.  Git chooses the editor to launch in this order: the value of the ~GIT_EDITOR~ environment variable, its ~core.editor~ configuration variable, the ~VISUAL~ environment variable, and the ~EDITOR~ environment variable.  For example, we can tell Git to use terminal Emacs to edit commit messages with
 
 #+begin_src sh
   git config core.editor "emacs -nw"
@@ -155,7 +155,7 @@ To commit your changes run
   git commit
 #+end_src
 
-Your editor should now be displaying the commit template, which provides tips on creating a commit message.  There should be a short subject line that takes the form ~<part of the ports tree that is changing>: <brief overview of the change>~.  A good subject line might be ~www/nyxt: (WIP) First attempt to port Nyxt browser~.  The body of the commit message provides more detail.  An example might be
+Your editor should now be displaying the commit template, which provides tips on creating a commit message.  The subject line should be no longer than 50 characters, take the form ~<part of the ports tree that is changing>: <brief overview of the change>~, and be followed by a blank line.  A good subject line might be ~www/nyxt: (WIP) First attempt to port Nyxt browser~.  The body of the commit message provides more detail.  An example might be
 
 #+BEGIN_EXAMPLE
 Makefile is still a skeleton.
@@ -167,7 +167,7 @@ TODO:
 - Add do-build target
 #+END_EXAMPLE
 
-After saving and exiting the editor your changes will be committed.  To recap, our changes progressed from the working tree, to the staging area (index), and finally to the local repository.  To inspect your commit, use ~git log~, which will also confirm that the ~HEAD~ and ~nyxt~ pointers have advanced one commit ahead of the main branch pointer.
+After saving and exiting the editor your changes will be committed.  So far, our changes progressed from the working tree, to the staging area (index), and finally to the local repository.  To inspect your commit, use ~git log~, which will also confirm that the ~HEAD~ and ~nyxt~ pointers have advanced one commit ahead of the main branch pointer.
 
 ** Rewriting Local History
 
@@ -211,7 +211,7 @@ Be aware, while these tools are generally quite helpful, they do not catch all m
   poudriere ports -c -m null -M /usr/ports
 #+end_src
 
-The ~-m~ option tells poudriere to use the null method, i.e., use an existing ports tree found at the location specified as the argument to ~-M~.  Using the null method means that we will manually manage the tree, including keeping it up-to-date and checking out the appropriate branch when testing.  Once you have poudriere set up, we can test our port.  If you created a jail named 13amd64, you can test the new port in that jail with
+The ~-m~ option tells poudriere to use the null method, i.e., use an existing ports tree found at the location specified as the argument to ~-M~.  Using the null method means that we will manually manage the tree, including keeping it up-to-date and checking out the appropriate branch when testing.  Once you have poudriere set up, you can test your port.  If you created a jail named 13amd64, you can test the new port in that jail with
 
 #+begin_src
   poudriere testport -j 13amd64 www/nyxt
@@ -219,12 +219,12 @@ The ~-m~ option tells poudriere to use the null method, i.e., use an existing po
 
 Ideally you should test your port on the various [[https://www.freebsd.org/platforms/][tier 1 platforms]] (currently 12i386, 12amd64, 13amd64, and 13arm64).
 
-To run-time test your new port, poudriere can build a package and leave the jail running with the package installed.
+To =test your new port after building it, poudriere can build a package and leave the jail running with the package installed.
 
 #+begin_src
   poudriere bulk -i -j 13amd64 <category>/<port>
 #+end_src
-It's ~-i~ that instructs poudriere to leave the jail running with the package installed.  This is useful for run-time testing terminal application, but not graphical applications like nyxt.
+It's ~-i~ that instructs poudriere to leave the jail running with the package installed.  This is useful for testing terminal applications, but not graphical applications like nyxt.
 
 If the port has OPTIONS, poudriere will test and build the package as the official package builder will, i.e., with the default OPTIONS chosen.  If you want to test or build the package with non-default options, you can run
 
@@ -234,7 +234,7 @@ If the port has OPTIONS, poudriere will test and build the package as the offici
 
 before ~poudriere testport...~ or ~poudriere bulk...~.
 
-Poudriere also creates a repository that pkg can use to install packages.  If you want to install the package on the same system as poudriere, you have to configure pkg to use it.  From [[https://www.freebsd.org/cgi/man.cgi?pkg.conf(5)][PKG.CONF(5)]], a local configuration can be placed under /usr/local/etc/pkg/repos/.  The name of the file is not important, but it must have a ~.conf~ suffix.  To set a local repository configuration and disable the default official repository configured in /etc/pkg/FreeBSD.conf, create /usr/local/etc/pkg/repos/local.conf with
+Poudriere also creates a repository that pkg can use to install packages.  If you want to install the package on the same system as poudriere, you have to configure pkg to use it.  From [[https://www.freebsd.org/cgi/man.cgi?pkg.conf(5)][pkg.conf(5)]], a local configuration can be placed under /usr/local/etc/pkg/repos/.  The name of the file is not important, but it must have a ~.conf~ suffix.  To set a local repository configuration and disable the default official repository configured in /etc/pkg/FreeBSD.conf, create /usr/local/etc/pkg/repos/local.conf with
 
 #+BEGIN_EXAMPLE
 FreeBSD: {
@@ -307,7 +307,7 @@ After restarting nginx with ~service nginx restart~, point your browser to ~http
 
 ** Rewriting History to Prepare for Review
 
-Before sharing your work, the commit history should be well organized, including the commit logs and the number of commits.  For example, maybe you snapshotted your work at the end of the day with a commit containing a message with
+Before sharing your work, the commit history should be well organized, including the commit logs and the number of commits.  For example, maybe you committed a day's work with a log message containing
 
 #+BEGIN_EXAMPLE
 www/nyxt: (WIP) First attempt to port Nyxt browser
@@ -517,6 +517,8 @@ To begin using FreeBSD's Phabricator instance for code review at https://reviews
   pkg install arcanist-php74
 #+end_src
 
+If you have a later version of PHP already installed, install the matching arcanist instead, for instance ~arcanist-php80~.
+
 Set up ~~/.arcrc~ with the required certificates by running
 
 #+begin_src sh
@@ -540,7 +542,7 @@ arc diff --create main
 This will create a new review with all the commits in the nyxt branch.  In this example, we squashed our commits into a single commit, so the revision will be created with that single commit.  When your editor opens, you will have the opportunity to edit the fields that are part of the revision.  The top line will be the subject of your commit log, ~www/nyxt: New port for the Nyxt browser~ and the summary will contain the rest of the commit log.  Under test plan, you can list what you did to test the port.  For example, if you did ~poudriere testport~ for each of the supported versions on the tier 1 architectures, you could write
 
 #+begin_EXAMPLE
-poudriere testport 12/13 amd64/arm64
+poudriere testport 12/13 amd64/aarch64
 #+end_EXAMPLE
 
 You must also add at least one reviewer.  If you have one or more ports committers that you have been working with, you can add their usernames here.  For example
@@ -561,16 +563,16 @@ where <revision> is the revision ID and takes the form DXXXXX.  It can be found 
 
 To create a new Bugzilla bug, point your browser to https://bugs.freebsd.org and click the ~New~ link at the top of the page.  If you are not logged in to the FreeBSD Bugzilla instance, you will be prompted to do so.  If you do not have a FreeBSD Bugzilla account, you can use the link on the login page to create a new one.
 
-From here, you choose the ~Ports & Packages~ link since we are creating a new port and choose ~Individual Port(s)~ for the ~Component~.  For ports-specific bugs, the bug's subject line can be the same as the commit subject, i.e., ~www/nyxt: New port for the Nyxt browser~.  If the port isn't new, the ~category/port~ prefix will automatically assign the bug to the maintainer of the port.  In the description you can add the information the rest of the commit log and any other information helpful for others reading the bug, like a link to the phabricator review.
+From here, you choose the ~Ports & Packages~ link since we are creating a new port and choose ~Individual Port(s)~ for the ~Component~.  For ports-specific bugs, the bug's subject line can be the same as the commit subject, i.e., ~[NEW PORT] www/nyxt: New port for the Nyxt browser~.  If the port isn't new, the ~category/port~ prefix will automatically assign the bug to the maintainer of the port.  In the description you can add the rest of the commit message and other information helpful for others reading the bug.  If you started a Phabricator review, add it to ~See also~.
 
-When your new port is accepted and pushed to git.freebsd.org/ports.git, your new job as the maintainer of the port begins.  For an outline of the responsibilities of port maintainers, refer to the [[https://docs.freebsd.org/en/articles/contributing/#maintain-port][The challenge for port maintainers article.]]  To keep up-to-date with upstream, [[https://portscout.freebsd.org/][portscout]] is a helpful service to alert when there is a new release, so you can submit a port update.  If upstream uses GitHub, you can also be alerted of new releases by following the ~Watch~ and ~Custom~ links, then check ~Releases~ on the project's page.  When there simple updates to your port that only contain a change to the ~DISTVERSION~ line and the ~distinfo~ file, submitting a Phabricator review is not necessary.  It is sufficient to create a patch using (from the feature branch):
+When your new port is accepted and pushed to git.freebsd.org/ports.git, your new job as the maintainer of the port begins.  For an outline of the responsibilities of port maintainers, refer to the [[https://docs.freebsd.org/en/articles/contributing/#maintain-port][The challenge for port maintainers article.]]  To keep up-to-date with upstream, [[https://portscout.freebsd.org/][portscout]] is a helpful service to alert when there is a new release, so you can submit a port update.  If upstream uses GitHub, you can also be alerted of new releases by following the ~Watch~ and ~Custom~ links, then check ~Releases~ on the project's page.  When your port update is simple and only contains a change to the ~DISTVERSION~ line and the ~distinfo~ file, submitting a Phabricator review is not necessary.  A patch using (from the feature branch):
 
 #+begin_src sh
   git format-patch main
 #+end_src
 
-and attach it to a Bugzilla bug.  Another desirable feature of Git is the option for committers to commit as different users.  This means when you submit a patch and a committer pushes it to git.freebsd.org/ports.git, ~git log~ will give you credit for your work by showing you as the author of the commit.
+and attached to a Bugzilla bug is enough.  Another desirable feature of Git is the option for committers to commit as different users.  This means when you submit a patch and a committer pushes it to git.freebsd.org/ports.git, ~git log~ will give you credit for your work by showing you as the author of the commit.
 
 ** Opinionated Conclusions
 
-Change can be hard.  Many FreeBSD developers and contributors who dedicated significant time to becoming productive using Subversion, were reluctant to change to a new version control system, especially one so fundamentally different.  We lost some practical features like simple, monotonically increasing commit revisions and deterministic history retention when directories and files are moved within the repository.  However, after three quarters of year, most indications suggest developers and the wider community are pleased and productive with the change.  It is difficult to isolate the cause of certain outcomes, but the number of commits to the ports tree from the conversion date until the time of writing, 2021-04-06 to 2021-12-06 is 27,043.  This is a few thousand more than the number for the same time last year, which was 24,945.  Let's hope this is a continuing trend in contributions to the ports tree.
+Change can be hard.  Many FreeBSD developers and contributors, who dedicated significant time to becoming productive using Subversion, were reluctant to change to a new version control system, especially one so fundamentally different.  We lost some practical features like simple, monotonically increasing commit revisions and deterministic history retention when directories and files are moved within the repository.  However, after three quarters of year, most indications suggest developers and the wider community are pleased and productive with the change.  It is difficult to isolate the cause of certain outcomes, but the number of commits to the ports tree from the conversion date until the time of writing, 2021-04-06 to 2021-12-06 is 27,043.  This is a few thousand more than the number for the same time last year, which was 24,945.  Let's hope this is a continuing trend in contributions to the ports tree.


### PR DESCRIPTION
- "From an implementation perspective" Clarity: if you mean "implementation" as in "how git and workflow fit together, I'd use "project-wide workflow" instead. If you mean "how git works", it's design and use, not implementation. I'm assuming the latter.
- "The history of a Git repository can be considered as a directed acyclic graph with nodes of the graph repository snapshots." Concision, completeness: "can be considered as" -> "is", "nodes of the graphs repository snapshots" -> "nodes of the graphs being repository snapshots" (and I'd add something about what edges are, maybe "and edges being commits").
- "Creating a new branch means starting a new line of development" Clarity: define "line of development", or maybe better, list (here or later) what a port maintainer is likely to use a new branch for (if that port maintainer is me, that's almost always "upgrade to new upstream version", but may not be that for a port committer or even maintainers who are not me). Going for "; for ports, it will usually propose a new port or upgrade an existing one you maintain".
- "From a user perspective, support for lightweight local branches and the simplicity of switching between and merging the work of different branches is..." Sentence flow, concision: rewriting as "...Git's support of lightweight local branches, easy switching between branches, and merging different branches are..." "...Git’s defining feature" Terminology quibble: I'd write "strong points" instead, because you wrote earlier "the defining property that makes Git different" and while they each can be "a defining (mumble)", they can't be both be "the defining (mumble)" IMO. (Which also means that if you want to keep "defining" here, you need to change "the" to "a" both here and in that earlier use.)
- "we value a simple linear history" Precision and accuracy: changed  to "the ports committers require".
- "so viewing the history of the FreeBSD ports main branch under Git looks similar to how the history looked under Subversion" Concision: "so the history of the FreeBSD ports main branch under Git looks similar to how it looked under Subversion"
- "This requires certain constraints when developers" Precision: again, I'd say "port committers".
- "a different workflow that results in parallel paths along in the main branch" Accuracy, grammar: I'd reword it as "a different overall process that relies on parallel paths along with the main branch" (which is sorta-kinda what FreeBSD does for ports too - see quarterly port branches).
- "at the time of writing" Future-proofing: I used "starting in October 2021" with a few other tweaks to that sentence.
- "This can only happen when the output of git log --oneline main..freebsd/main descends from the local main branch." Clarity, text flow: I'd swap this and the next sentence and use "To check whether this is the case in your local main branch, run git log --oneline main..freebsd/main and check for any local changes.
- "This can only happen when the output of git log --oneline main..freebsd/main descends from the local main branch." Clarity, text flow: I swapped this and the next sentence, tweaked that, and used "To check whether this is the case, run git log --oneline main..freebsd/main and check for any local changes." This is clearer wording for what I think you mean, but I'm only about 60-70% confident I interpreted that correctly, so proceed with caution.
- "As a convenience, there is a ~pull~ command that will do both the ~fetch~ and ~merge~." Concision, precision: "...the ~pull~ command will ~fetch~ then ~merge~."
- "Now that we are able to keep our repository copy up-to-date with git.freebsd.org/ports.git, let's start to think" Concision: "Now that we can", "let's think".
- "Start by creating a new feature branch to work on the new nyxt port." Completeness: I added a link to https://docs.freebsd.org/en/books/porters-handbook/new-port/, but check my markup in case I misunderstood the link markup syntax you used elsewhere.
- "If you ever want to check which branch you have checked out, you can run" Concision, tone: "To check which branch you have checked out, ..."
- "At the time of writing there is only one hook in that location, prepare-commit-msg, which..." Future-proofing, nomenclature: I made that "That directory contains the prepare-commit-msg hook, which..."
- "There should be a short subject line" Consistency with git-commit(1): Added "no more than 50 characters" and mentioned the blank line git expects before the commit message body.
- "To recap" EFL friendliness: "To recapitulate" or "So far" (went with the latter).
- "Once you have poudriere set up, we can test our port." Pronouns consistency: use only one of "you" and "we". (I went with "you"/"your" for all 3.)
- "for run-time testing terminal application" Grammar, EFL friendliness: "for testing terminal applications".
- "From PKG.CONF(5)," Consistency with actual manual page; used lowercase.
- "you snapshotted your work at the end of the day with a commit containing a message with..." Taste, concision: "you committed a day's work with a log message containing...".
- "pkg install arcanist-php74" or the one for your PHP version, eg arcanist-php80.
- "poudriere testport 12/13 amd64/arm64" Consistency with FreeBSD nomenclature: "aarch64", not "arm64".
- "www/nyxt: New port for the Nyxt browser" Consistency: per https://docs.freebsd.org/en/books/porters-handbook/quick-porting/#porting-submitting, make it "[NEW PORT] www/nyxt: New port for the Nyxt browser".
- "In the description you can add the information the rest of the commit log and any other information helpful for others reading the bug, like a link to the phabricator review." Concision, missing word: s/the information the rest of the commit log/the rest of the commit log message/ Accuracy: Phabricator review link would go in "See also" (and it needs an uppercase initial).
- "When there simple updates to your port that only contain ..." Grammar, taste: "When your port update is simple and only contains ..."
- "It is sufficient to ..." Taste, concision: "... is enough."
- "Many FreeBSD developers and contributors who dedicated significant time to becoming productive using Subversion," Punctuation: remove this comma or add one after "contributors". (Went for the latter.)